### PR TITLE
replace schedulers with :execute commands

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,13 +13,6 @@
     commands: /system clock set time-zone-autodetect=no time-zone-name={{ routeros_timezone }}
   tags: [ "install" ]
 
-- name: create scheduler reboot
-  routeros_command:
-    commands:
-      - /system scheduler add disabled=yes interval=1s name=reboot-mt-on-demand policy=reboot,read,write,policy,test,password,sniff,sensitive start-date=jan/01/1970 start-time=00:00:00 on-event="/system scheduler disable reboot-mt-on-demand;/system reboot;"
-      - /system scheduler add disabled=yes interval=1s name=shutdown-mt-on-demand policy=reboot,read,write,policy,test,password,sniff,sensitive start-date=jan/01/1970 start-time=00:00:00 on-event="/system scheduler disable shutdown-mt-on-demand;/system shutdown;"
-  tags: [ "install" ]
-
 - name: "disable sensitive service [ telnet, ftp, www, api, api-ssl ]"
   routeros_command:
     commands: /ip service disable {{ item }}

--- a/tasks/reboot.yml
+++ b/tasks/reboot.yml
@@ -1,3 +1,3 @@
-- name: attiva scheduler
+- name: reboot device
   routeros_command:
-    commands: /system scheduler enable reboot-mt-on-demand
+    commands: ":execute {/system reboot};"

--- a/tasks/shutdown.yml
+++ b/tasks/shutdown.yml
@@ -1,3 +1,3 @@
-- name: attiva scheduler
+- name: shutdown device
   routeros_command:
-    commands: /system scheduler enable shutdown-mt-on-demand
+    commands: ":execute {/system shutdown};"


### PR DESCRIPTION
With the `:execute {/system reboot};` commands, there is no need for an extra scheduler to be able to reboot or shutdown devices without a confirmation.